### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/jojomi/assert/security/code-scanning/1](https://github.com/jojomi/assert/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks (checkout, setup Go, build, and test), it only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
